### PR TITLE
Fix the hostname for the SPAR Soap service

### DIFF
--- a/src/personsok_fraga.php
+++ b/src/personsok_fraga.php
@@ -22,7 +22,7 @@ function skapaSoapClient()
         'local_cert' => $_POST['certifikat'],
         'verify_peer' => true,
         'cafile' => $_POST['ca'],
-        'CN_match' => 'kt-ext-portwise.statenspersonadressregister.se');
+        'CN_match' => 'test-personsok.statenspersonadressregister.se');
 
     $streamcontext = stream_context_create(
         array('ssl' => $sslOptions));

--- a/src/personsok_sokform.php
+++ b/src/personsok_sokform.php
@@ -69,7 +69,7 @@
         <section id="kommunikation">
             <h1>Kommunikationsparametrar för SOAP-anropet</h1>
             <label for="k1"> URL till tjänst</label>
-            <input id="k1" name="url" type="text" value="https://kt-ext-ws.statenspersonadressregister.se/2021.1/"/>
+            <input id="k1" name="url" type="text" value="https://test-personsok.statenspersonadressregister.se/2021.1/"/>
 
             <label for="k2">Klientcertifikat (PEM)
                 <input id="k2" name="certifikat" type="text" value="resurser/Kommun_A.pem"/>


### PR DESCRIPTION
The current hostname kt-ext-ws.statenspersonadressregister.se used in this reference implementation fails with a connection error. It should probably be test-personsok.statenspersonadressregister.se instead as this works fine.